### PR TITLE
Configure build output for Foundry VTT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Crow Nest
+
+Crow Nest es un módulo para Foundry VTT. Para compilarlo y cargarlo en Foundry sigue estos pasos:
+
+1. Instala las dependencias (solo la primera vez):
+   ```bash
+   npm install
+   ```
+2. Genera los archivos de `dist`:
+   ```bash
+   npm run build
+   ```
+3. Copia todo el proyecto, incluido `module.json` y la carpeta `dist`, en la carpeta de módulos de Foundry VTT. Por ejemplo:
+   `FoundryData/Data/modules/crow-nest/`
+4. Reinicia Foundry VTT y activa el módulo desde la sección **Add-on Modules**.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,8 +7,13 @@ export default defineConfig({
   build: {
     outDir: "../dist",
     emptyOutDir: true,
+    assetsDir: "",
     rollupOptions: {
       input: "src/main.ts",
+      output: {
+        entryFileNames: "main.js",
+        assetFileNames: "[name][extname]",
+      },
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary
- configure Vite output so Foundry expects `dist/main.js` and `dist/global.css`
- add Spanish README with instructions to build and copy the module

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870e12d6eb88321ad08d77c9b149176