### PR TITLE
Add draggable HUD with popup button

### DIFF
--- a/src/components/hud/hud.svelte
+++ b/src/components/hud/hud.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import Popup from "@/components/popup/popup.svelte";
+
+  let pos = { x: 20, y: 20 };
+  let isDragging = false;
+  let offset = { x: 0, y: 0 };
+  let showPopup = false;
+
+  function onMouseDown(event: MouseEvent) {
+    isDragging = true;
+    offset = {
+      x: event.clientX - pos.x,
+      y: event.clientY - pos.y,
+    };
+    window.addEventListener("mousemove", onMouseMove);
+    window.addEventListener("mouseup", onMouseUp);
+  }
+
+  function onMouseMove(event: MouseEvent) {
+    if (!isDragging) return;
+    pos = {
+      x: event.clientX - offset.x,
+      y: event.clientY - offset.y,
+    };
+  }
+
+  function onMouseUp() {
+    isDragging = false;
+    window.removeEventListener("mousemove", onMouseMove);
+    window.removeEventListener("mouseup", onMouseUp);
+  }
+
+  function togglePopup() {
+    showPopup = !showPopup;
+  }
+</script>
+
+<style>
+  .hud {
+    position: fixed;
+    top: 0;
+    left: 0;
+    background: rgba(0, 0, 0, 0.5);
+    color: white;
+    padding: 0.5rem;
+    border-radius: 0.5rem;
+    user-select: none;
+    cursor: move;
+    z-index: 1000;
+  }
+</style>
+
+<div
+  class="hud"
+  style="transform: translate({pos.x}px, {pos.y}px);"
+  on:mousedown={onMouseDown}
+>
+  <button on:click|stopPropagation={togglePopup}>Abrir Popup</button>
+</div>
+
+{#if showPopup}
+  <Popup title="Crow Nest Ready" />
+{/if}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import Popup from "@/components/popup/popup.svelte";
+import Hud from "@/components/hud/hud.svelte";
 
 Hooks.once("init", () => {
   console.log("Crow Nest | Initializing module");
@@ -11,5 +11,5 @@ Hooks.once("ready", () => {
 Hooks.once("ready", () => {
   const container = document.createElement("div");
   document.body.appendChild(container);
-  new Popup({ target: container, props: { title: "Crow Nest Ready" } });
+  new Hud({ target: container });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,7 +21,9 @@ export default defineConfig({
       "@": path.resolve(__dirname, "src"),
     },
   },
-  plugins: [svelte()],
+  plugins: [
+    svelte({ configFile: path.resolve(__dirname, "svelte.config.js") }),
+  ],
   css: {
     postcss: "../postcss.config.cjs",
   },


### PR DESCRIPTION
## Summary
- build HUD with a draggable container and a button to open the Popup
- mount HUD on ready
- load Svelte config explicitly in Vite so TypeScript is processed

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870e98b2870832199c213c2b52e8456