### PR TITLE
Improve popup and add guard component

### DIFF
--- a/src/components/guard/guard.css
+++ b/src/components/guard/guard.css
@@ -1,0 +1,1 @@
+/* styles are defined in guard.svelte */

--- a/src/components/guard/guard.html
+++ b/src/components/guard/guard.html
@@ -1,0 +1,1 @@
+<!-- Guard component placeholder used by Svelte -->

--- a/src/components/guard/guard.svelte
+++ b/src/components/guard/guard.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  interface Stat {
+    id: string;
+    name: string;
+    value: number;
+  }
+
+  let stats: Stat[] = [];
+  let log: string[] = [];
+  let showLog = false;
+
+  onMount(() => {
+    const savedStats = localStorage.getItem('crowGuardStats');
+    if (savedStats) stats = JSON.parse(savedStats);
+    const savedLog = localStorage.getItem('crowGuardLog');
+    if (savedLog) log = JSON.parse(savedLog);
+  });
+
+  function persist() {
+    localStorage.setItem('crowGuardStats', JSON.stringify(stats));
+    localStorage.setItem('crowGuardLog', JSON.stringify(log));
+  }
+
+  function addStat() {
+    const stat: Stat = { id: crypto.randomUUID(), name: '', value: 0 };
+    stats = [...stats, stat];
+    log = [...log, `Añadido stat ${stat.id}`];
+    persist();
+  }
+
+  function removeStat(index: number) {
+    const [removed] = stats.splice(index, 1);
+    stats = [...stats];
+    log = [...log, `Eliminado stat ${removed.id}`];
+    persist();
+  }
+
+  function updateStat() {
+    log = [...log, 'Modificados stats'];
+    persist();
+  }
+
+  function toggleLog() {
+    showLog = !showLog;
+  }
+</script>
+
+<style>
+  .guard-container {
+    padding: 0.5rem;
+    color: white;
+  }
+
+  .stat {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    margin-bottom: 0.25rem;
+  }
+
+  .stat img {
+    width: 24px;
+    height: 24px;
+  }
+
+  .log {
+    background: #333;
+    padding: 0.25rem;
+    margin-top: 0.5rem;
+    max-height: 150px;
+    overflow-y: auto;
+  }
+</style>
+
+<div class="guard-container">
+  <button on:click={addStat}>Añadir Stat</button>
+  {#each stats as stat, i}
+    <div class="stat">
+      <img src="icons/svg/shield.svg" alt="stat" />
+      <input placeholder="Nombre" bind:value={stat.name} on:change={updateStat} />
+      <input placeholder="ID" bind:value={stat.id} on:change={updateStat} />
+      <input type="number" placeholder="Valor" bind:value={stat.value} on:change={updateStat} />
+      <button on:click={() => removeStat(i)}>Quitar</button>
+    </div>
+  {/each}
+
+  <button on:click={toggleLog}>{showLog ? 'Ocultar Log' : 'Mostrar Log'}</button>
+  {#if showLog}
+    <div class="log">
+      {#each log as entry}
+        <div>{entry}</div>
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/src/components/guard/guard.ts
+++ b/src/components/guard/guard.ts
@@ -1,0 +1,2 @@
+import Guard from './guard.svelte';
+export default Guard;

--- a/src/components/hud/hud.svelte
+++ b/src/components/hud/hud.svelte
@@ -51,7 +51,7 @@
 
 <style>
   .hud-crow {
-    position: fixed;
+    position: absolute;
     top: 0;
     left: 0;
     background: rgba(0, 0, 0, 0.5);
@@ -83,5 +83,5 @@
 </div>
 
 {#if showPopup}
-  <Popup title="Crow Nest Ready" />
+  <Popup title="Crow Nest Ready" on:close={togglePopup} />
 {/if}

--- a/src/components/popup/popup.svelte
+++ b/src/components/popup/popup.svelte
@@ -1,17 +1,83 @@
 <script lang="ts">
-  export let title = "Crow Nest Popup";
+  import { createEventDispatcher, onMount } from 'svelte';
+
+  export let title = 'Crow Nest Popup';
+  const dispatch = createEventDispatcher();
+
+  let pos = { x: 0, y: 0 };
+  let dragging = false;
+  let offset = { x: 0, y: 0 };
+
+  onMount(() => {
+    pos = { x: window.innerWidth / 2 - 150, y: window.innerHeight / 2 - 100 };
+  });
+
+  function onHeaderDown(event: MouseEvent) {
+    dragging = true;
+    offset = {
+      x: event.clientX - pos.x,
+      y: event.clientY - pos.y,
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+  }
+
+  function onMove(event: MouseEvent) {
+    if (!dragging) return;
+    pos = {
+      x: event.clientX - offset.x,
+      y: event.clientY - offset.y,
+    };
+  }
+
+  function onUp() {
+    dragging = false;
+    window.removeEventListener('mousemove', onMove);
+    window.removeEventListener('mouseup', onUp);
+  }
+
+  function close() {
+    dispatch('close');
+  }
 </script>
 
 <style>
-  .popup {
-    padding: 1rem;
+  .window-app {
+    position: absolute;
     background: #222;
     color: white;
-    border-radius: 0.5rem;
+    border: 1px solid #555;
+    border-radius: 4px;
+    width: 300px;
+  }
+
+  header {
+    background: #444;
+    padding: 0.25rem;
+    cursor: move;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .close {
+    cursor: pointer;
+  }
+
+  .content {
+    padding: 0.5rem;
   }
 </style>
 
-<div class="popup">
-  <h2>{title}</h2>
-  <slot />
+<div
+  class="window-app"
+  style="transform: translate({pos.x}px, {pos.y}px);"
+>
+  <header on:mousedown={onHeaderDown}>
+    <span>{title}</span>
+    <a class="close" on:click={close}>×</a>
+  </header>
+  <div class="content">
+    <slot />
+  </div>
 </div>

--- a/src/components/popup/popup.ts
+++ b/src/components/popup/popup.ts
@@ -1,0 +1,2 @@
+import Popup from './popup.svelte';
+export default Popup;


### PR DESCRIPTION
## Summary
- make HUD container absolutely positioned
- implement a draggable Foundry-style popup window
- add Guard component for customizable stats with persistent logging

## Testing
- `npm run lint --silent` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6870f8574144832193d0a0a2dfd39893