### PR TITLE
Add Guard inside popup and style it

### DIFF
--- a/src/components/hud/hud.svelte
+++ b/src/components/hud/hud.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import Popup from "@/components/popup/popup.svelte";
+  import Guard from "@/components/guard/guard.svelte";
 
   let pos = { x: 0, y: 0 };
   let isDragging = false;
@@ -83,5 +84,7 @@
 </div>
 
 {#if showPopup}
-  <Popup title="Crow Nest Ready" on:close={togglePopup} />
+  <Popup title="Crow Nest Ready" on:close={togglePopup}>
+    <Guard />
+  </Popup>
 {/if}

--- a/src/components/popup/popup.svelte
+++ b/src/components/popup/popup.svelte
@@ -44,11 +44,17 @@
 <style>
   .window-app {
     position: absolute;
-    background: #222;
+    background: rgba(11, 10, 19, 0.9);
     color: white;
     border: 1px solid #555;
     border-radius: 4px;
-    width: 300px;
+    min-width: 800px;
+    box-shadow: rgb(0, 0, 0) 0px 0px 10px 0px;
+  }
+
+  .backdrop {
+    backdrop-filter: blur(4px);
+    border: 0.8px solid rgb(243, 194, 103);
   }
 
   header {
@@ -77,7 +83,9 @@
     <span>{title}</span>
     <a class="close" on:click={close}>×</a>
   </header>
-  <div class="content">
-    <slot />
+  <div class="backdrop">
+    <div class="content">
+      <slot />
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- include Guard component in HUD popup
- style popup width, backdrop and shadow

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870fd7624e88321beda66f4090e70c7