### PR TITLE
Add resource tracking and popup resize

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,3 +2,4 @@ export const MODULE_ID = "crow-nest";
 export const SETTING_STATS = "guard-stats";
 export const SETTING_LOG = "guard-stat-log";
 export const SETTING_MODIFIERS = "guard-modifiers";
+export const SETTING_RESOURCES = "guard-resources";

--- a/src/guard/stats.ts
+++ b/src/guard/stats.ts
@@ -3,6 +3,7 @@ import {
   SETTING_STATS,
   SETTING_LOG,
   SETTING_MODIFIERS,
+  SETTING_RESOURCES,
 } from "@/constants";
 
 export interface GuardStat {
@@ -25,6 +26,13 @@ export interface GuardModifier {
   name: string;
   img?: string;
   mods: Record<string, number>;
+}
+
+export interface GuardResource {
+  key: string;
+  name: string;
+  value: number;
+  img?: string;
 }
 
 export function getStats(): GuardStat[] {
@@ -50,4 +58,14 @@ export async function saveModifiers(
   modifiers: GuardModifier[]
 ): Promise<void> {
   await game.settings.set(MODULE_ID, SETTING_MODIFIERS, modifiers);
+}
+
+export function getResources(): GuardResource[] {
+  return (
+    game.settings.get(MODULE_ID, SETTING_RESOURCES) as GuardResource[]
+  ) ?? [];
+}
+
+export async function saveResources(resources: GuardResource[]): Promise<void> {
+  await game.settings.set(MODULE_ID, SETTING_RESOURCES, resources);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import {
   SETTING_STATS,
   SETTING_LOG,
   SETTING_MODIFIERS,
+  SETTING_RESOURCES,
 } from "@/constants";
 import "./styles/global.pcss";
 
@@ -23,6 +24,12 @@ Hooks.once("init", () => {
     default: [],
   });
   game.settings.register(MODULE_ID, SETTING_MODIFIERS, {
+    scope: "world",
+    config: false,
+    type: Array,
+    default: [],
+  });
+  game.settings.register(MODULE_ID, SETTING_RESOURCES, {
     scope: "world",
     config: false,
     type: Array,


### PR DESCRIPTION
## Summary
- support persistent resource tracking
- hide add buttons until editing
- add draggable resizer that persists popup size

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build`
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_68712aa65890832187aac505141d6bb0