### PR TITLE
Improve patrol modifiers and tooltips

### DIFF
--- a/src/components/tooltip.svelte
+++ b/src/components/tooltip.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import { tick } from 'svelte';
+  export let content = '';
+  let show = false;
+  let tooltipEl: HTMLDivElement;
+  let wrapperEl: HTMLDivElement;
+
+  async function position() {
+    await tick();
+    if (!tooltipEl || !wrapperEl) return;
+    const wrap = wrapperEl.getBoundingClientRect();
+    const tip = tooltipEl.getBoundingClientRect();
+    let left = (wrap.width - tip.width) / 2;
+    left = Math.max(0, Math.min(left, wrap.width - tip.width));
+    let top = -tip.height - 4;
+    if (top < -wrap.top) {
+      top = wrap.height + 4;
+    }
+    tooltipEl.style.left = `${left}px`;
+    tooltipEl.style.top = `${top}px`;
+  }
+
+  function onEnter() {
+    show = true;
+    position();
+  }
+  function onLeave() {
+    show = false;
+  }
+</script>
+
+<div class="tooltip-wrapper" bind:this={wrapperEl} on:mouseenter={onEnter} on:mouseleave={onLeave}>
+  <slot></slot>
+  {#if show}
+    <div class="tooltip" bind:this={tooltipEl}>{content}</div>
+  {/if}
+</div>
+
+<style>
+  .tooltip-wrapper {
+    position: relative;
+    display: inline-block;
+  }
+  .tooltip {
+    position: absolute;
+    background: #333;
+    color: white;
+    padding: 0.25rem;
+    border-radius: 4px;
+    white-space: nowrap;
+    z-index: 10;
+    pointer-events: none;
+  }
+</style>

--- a/src/guard/stats.ts
+++ b/src/guard/stats.ts
@@ -24,6 +24,7 @@ export interface LogEntry {
 export interface GuardModifier {
   key: string;
   name: string;
+  description?: string;
   img?: string;
   mods: Record<string, number>;
 }

--- a/src/patrol/patrols.ts
+++ b/src/patrol/patrols.ts
@@ -17,12 +17,14 @@ export interface Patrol {
   name: string;
   officer: PatrolMember | null;
   soldiers: PatrolMember[];
-  modifier: number;
+  mods: Record<string, number>;
   skills: PatrolSkill[];
 }
 
 export function getPatrols(): Patrol[] {
-  return (game.settings.get(MODULE_ID, SETTING_PATROLS) as Patrol[]) ?? [];
+  const stored =
+    (game.settings.get(MODULE_ID, SETTING_PATROLS) as Patrol[]) ?? [];
+  return stored.map((p) => ({ mods: {}, ...p }));
 }
 
 export async function savePatrols(patrols: Patrol[]): Promise<void> {


### PR DESCRIPTION
## Summary
- add editable per-stat modifiers to patrols
- implement Tooltip component that keeps tooltips inside their container
- move soldier names and patrol stat names into tooltips
- add description field to Guard modifiers and show it via tooltip

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68715e6916308321b4d7d9ed2ff90489