### PR TITLE
Enable HTML content for tooltips

### DIFF
--- a/src/components/guard/guard.svelte
+++ b/src/components/guard/guard.svelte
@@ -140,10 +140,10 @@
         const stat = stats.find((s) => s.key === k);
         if (!stat) return '';
         const val = Number(v) > 0 ? `+${v}` : `${v}`;
-        return `${stat.name}: ${val}`;
+        return `<div><strong>${stat.name}:</strong> ${val}</div>`;
       })
       .filter(Boolean)
-      .join(', ');
+      .join('');
   }
 
   function toggleEditingMods() {
@@ -437,7 +437,7 @@
   <div class="modifier-container">
   {#each modifiers as mod, i}
     <div class="modifier">
-      <Tooltip content={`${mod.name}: ${mod.description ?? ''}`}> 
+      <Tooltip content={`<p><strong>${mod.name}:</strong> ${mod.description ?? ''}</p>`}>
         <img class="standard-image" src={mod.img || 'icons/svg/upgrade.svg'} alt="mod" on:click={() => onModImageClick(mod)} />
       </Tooltip>
       <input id={`mod-file-${mod.key}`} type="file" accept="image/*" style="display:none" on:change={(e)=>onModFileChange(mod,e)} />

--- a/src/components/patrols/patrols.svelte
+++ b/src/components/patrols/patrols.svelte
@@ -253,7 +253,7 @@
             draggable="true"
             on:dragstart={(e) => onDragMember(e, s)}
           >
-            <Tooltip content={s.name}>
+            <Tooltip content={`<span>${s.name}</span>`}>
               <img
                 src={s.img}
                 alt={s.name}
@@ -272,7 +272,7 @@
       <div>
         {#each stats as stat}
           <div class="patrol-stat">
-            <Tooltip content={stat.name}>
+            <Tooltip content={`<span>${stat.name}</span>`}>
               <button class="stat-icon" on:click={() => roll(stat, patrol)}>
                 <img src={stat.img || 'icons/svg/shield.svg'} alt={stat.name} />
               </button>

--- a/src/components/tooltip.svelte
+++ b/src/components/tooltip.svelte
@@ -32,7 +32,9 @@
 <div class="tooltip-wrapper" bind:this={wrapperEl} on:mouseenter={onEnter} on:mouseleave={onLeave}>
   <slot></slot>
   {#if show}
-    <div class="tooltip" bind:this={tooltipEl}>{content}</div>
+    <div class="tooltip" bind:this={tooltipEl}>
+      {@html content}
+    </div>
   {/if}
 </div>
 


### PR DESCRIPTION
## Summary
- convert modifier tooltip text into HTML blocks
- wrap patrol tooltip values in basic HTML
- modify `modChanges` to generate HTML strings

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68716390a9cc8321a8f0b4d93a34c17e