### PR TITLE
Fix groups popup initialization

### DIFF
--- a/src/components/hud/hud.svelte
+++ b/src/components/hud/hud.svelte
@@ -90,8 +90,8 @@
   <Popup title="Crow Nest Ready" on:close={togglePopup}>
     <Guard />
     <Groups
-      {getAdmins}
-      {saveAdmins}
+      getGroups={getAdmins}
+      saveGroups={saveAdmins}
       labels={{
         groupSingular: 'Administrador',
         addGroup: 'Añadir Administrador',
@@ -101,8 +101,8 @@
       }}
     />
     <Groups
-      {getPatrols}
-      {savePatrols}
+      getGroups={getPatrols}
+      saveGroups={savePatrols}
       labels={{
         groupSingular: 'Patrulla',
         addGroup: 'Añadir Patrulla',


### PR DESCRIPTION
## Summary
- pass expected props to the `Groups` component

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68716c13d77c83218933ab0145794c9c