### PR TITLE
Implement popup resize clamp and image picker

### DIFF
--- a/src/components/groups/groups.svelte
+++ b/src/components/groups/groups.svelte
@@ -5,6 +5,8 @@
   import type { Group, GroupSkill, GroupMember } from "@/shared/group";
   import { onMount } from 'svelte';
 
+  declare const FilePicker: any;
+
   export let getGroups: () => Group[];
   export let saveGroups: (groups: Group[]) => Promise<void>;
   export let labels = {
@@ -119,7 +121,7 @@
   }
 
   function addSkill(group: Group) {
-    const skill: GroupSkill = { name: '', description: '', img: '' };
+    const skill: GroupSkill = { name: '', description: '', img: 'icons/svg/book.svg' };
     group.skills = [...group.skills, skill];
     groups = [...groups];
     persist();
@@ -130,6 +132,22 @@
     group.skills = [...group.skills];
     groups = [...groups];
     persist();
+  }
+
+  function chooseSkillImage(skill: GroupSkill) {
+    // Prefer Foundry's file picker when available
+    if (typeof FilePicker !== 'undefined') {
+      // @ts-ignore - FilePicker is provided by Foundry at runtime
+      FilePicker.create({
+        type: 'image',
+        current: skill.img,
+        callback: (path: string) => {
+          skill.img = path;
+          groups = [...groups];
+          persist();
+        },
+      }).render(true);
+    }
   }
 
   function guardBonus(key: string): number {
@@ -289,14 +307,14 @@
       </button>
       <div class="skills">
         <strong>Habilidades</strong>
-        {#each group.skills as sk, j}
-          <div class="skill">
-            <img src={sk.img} alt="" />
-            <input placeholder="Imagen" bind:value={sk.img} on:change={persist} />
-            <input placeholder="Nombre" bind:value={sk.name} on:change={persist} />
-            <input placeholder="Descripción" bind:value={sk.description} on:change={persist} />
-            <button on:click={() => removeSkill(group, j)}>Quitar</button>
-          </div>
+          {#each group.skills as sk, j}
+            <div class="skill">
+              <img src={sk.img} alt="" on:click={() => chooseSkillImage(sk)} />
+              <input placeholder="Imagen" bind:value={sk.img} on:change={persist} />
+              <input placeholder="Nombre" bind:value={sk.name} on:change={persist} />
+              <input placeholder="Descripción" bind:value={sk.description} on:change={persist} />
+              <button on:click={() => removeSkill(group, j)}>Quitar</button>
+            </div>
         {/each}
         <button on:click={() => addSkill(group)}>Añadir Habilidad</button>
       </div>

--- a/src/components/popup/popup.svelte
+++ b/src/components/popup/popup.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createEventDispatcher, onMount } from 'svelte';
+  import { createEventDispatcher, onMount, onDestroy } from 'svelte';
 
   export let title = 'Crow Nest Popup';
   const dispatch = createEventDispatcher();
@@ -11,10 +11,26 @@
   let resizing = false;
   let startResize = { x: 0, y: 0, width: 0, height: 0 };
 
+  function clampToViewport() {
+    const margin = 20;
+    const maxWidth = window.innerWidth - margin;
+    const maxHeight = window.innerHeight - margin;
+    size.width = Math.min(size.width, maxWidth);
+    size.height = Math.min(size.height, maxHeight);
+    pos.x = Math.min(Math.max(0, pos.x), window.innerWidth - size.width);
+    pos.y = Math.min(Math.max(0, pos.y), window.innerHeight - size.height);
+  }
+
   onMount(() => {
     pos = { x: window.innerWidth / 2 - 150, y: window.innerHeight / 2 - 100 };
     const saved = localStorage.getItem('crowPopupSize');
     if (saved) size = JSON.parse(saved);
+    clampToViewport();
+    window.addEventListener('resize', clampToViewport);
+  });
+
+  onDestroy(() => {
+    window.removeEventListener('resize', clampToViewport);
   });
 
   function onHeaderDown(event: MouseEvent) {


### PR DESCRIPTION
## Summary
- keep popup inside the viewport on window resize
- use a default icon for new skills and open the Foundry file picker when the image is clicked

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68717e0976508321abb2e1bf8064cc9d