### PR TITLE
Improve tooltip wrapping and patrol skill editor

### DIFF
--- a/src/components/groups/groups.svelte
+++ b/src/components/groups/groups.svelte
@@ -21,6 +21,7 @@
   let groups: Group[] = [];
   let modifiers: GuardModifier[] = [];
   let editingMods = false;
+  let editingSkills = false;
 
   onMount(() => {
     stats = getStats() as GuardStat[];
@@ -200,6 +201,15 @@
     height: 32px;
   }
 
+  .skill .info {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .skill textarea {
+    flex: 1;
+  }
+
   .member {
     display: flex;
     align-items: center;
@@ -309,14 +319,23 @@
         <strong>Habilidades</strong>
           {#each group.skills as sk, j}
             <div class="skill">
-              <img src={sk.img} alt="" on:click={() => chooseSkillImage(sk)} />
-              <input placeholder="Imagen" bind:value={sk.img} on:change={persist} />
-              <input placeholder="Nombre" bind:value={sk.name} on:change={persist} />
-              <input placeholder="Descripción" bind:value={sk.description} on:change={persist} />
-              <button on:click={() => removeSkill(group, j)}>Quitar</button>
+              <img src={sk.img} alt="" on:click={() => editingSkills && chooseSkillImage(sk)} />
+              {#if editingSkills}
+                <input placeholder="Nombre" bind:value={sk.name} on:change={persist} />
+                <textarea placeholder="Descripción" bind:value={sk.description} on:change={persist}></textarea>
+                <button on:click={() => removeSkill(group, j)}>Quitar</button>
+              {:else}
+                <div class="info">
+                  <strong>{sk.name}</strong>
+                  <p>{sk.description}</p>
+                </div>
+              {/if}
             </div>
         {/each}
         <button on:click={() => addSkill(group)}>Añadir Habilidad</button>
+        <button on:click={() => (editingSkills = !editingSkills)}>
+          {editingSkills ? 'Guardar Habilidades' : 'Editar Habilidades'}
+        </button>
       </div>
       <button
         class="deploy"

--- a/src/components/tooltip.svelte
+++ b/src/components/tooltip.svelte
@@ -49,7 +49,9 @@
     color: white;
     padding: 0.25rem;
     border-radius: 4px;
-    white-space: nowrap;
+    max-width: 100%;
+    white-space: normal;
+    word-wrap: break-word;
     z-index: 10;
     pointer-events: none;
   }


### PR DESCRIPTION
## Summary
- wrap tooltip contents and constrain width
- refactor patrol skills UI with an edit mode

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687183d883e48321b715f1690f585ddd