### PR TITLE
Fix tooltip positioning

### DIFF
--- a/src/components/tooltip.svelte
+++ b/src/components/tooltip.svelte
@@ -30,10 +30,10 @@
     const left = desiredLeft;
 
     let top = wrap.top - popup.top - tip.height - 4;
-    if (wrap.top + top < popup.top) {
+    if (top < 0) {
       top = wrap.top - popup.top + wrap.height + 4;
     }
-    if (wrap.top + top + tip.height > popup.bottom) {
+    if (top + tip.height > popup.height) {
       top = popup.height - tip.height;
     }
 
@@ -52,11 +52,9 @@
 
 <div class="tooltip-wrapper" bind:this={wrapperEl} on:mouseenter={onEnter} on:mouseleave={onLeave}>
   <slot></slot>
-  {#if show}
-    <div class="tooltip" bind:this={tooltipEl}>
-      {@html content}
-    </div>
-  {/if}
+  <div class="tooltip" bind:this={tooltipEl} style:display={show ? undefined : 'none'}>
+    {@html content}
+  </div>
 </div>
 
 <style>


### PR DESCRIPTION
## Summary
- correct tooltip position calculations
- hide tooltip instead of removing it so it can be inspected

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68719478b8708321907b6253259d3e71