### PR TITLE
Implement roll breakdown

### DIFF
--- a/src/components/groups/groups.svelte
+++ b/src/components/groups/groups.svelte
@@ -179,7 +179,18 @@
     const total = totalStat(stat, group);
     const r = new Roll(`1d20 + ${total}`);
     r.evaluate({ async: false });
-    r.toMessage({ speaker: { alias: group.officer || labels.groupSingular }, flavor: stat.name });
+
+    const lines: string[] = [];
+    for (const m of modifiers) {
+      const v = m.mods[stat.key];
+      if (v) lines.push(`${m.name} ${v > 0 ? '+' : ''}${v}`);
+    }
+    const groupMod = group.mods[stat.key];
+    if (groupMod) lines.push(`Modificador de la patrulla ${groupMod > 0 ? '+' : ''}${groupMod}`);
+
+    const flavor = [stat.name, ...lines].join('<br/>');
+    const alias = group.name || (group.officer ? `La Patrulla de ${group.officer.name}` : 'La Patrulla');
+    r.toMessage({ speaker: { alias }, flavor });
   }
 </script>
 

--- a/src/components/guard/guard.svelte
+++ b/src/components/guard/guard.svelte
@@ -169,7 +169,15 @@
       );
       const r = new Roll(`1d20 + ${stat.value + bonus}`);
       r.evaluate({ async: false });
-      r.toMessage({ speaker: { alias: 'Guardia' }, flavor: stat.name });
+
+      const lines: string[] = [];
+      for (const m of modifiers) {
+        const v = m.mods[stat.key];
+        if (v) lines.push(`${m.name} ${v > 0 ? '+' : ''}${v}`);
+      }
+
+      const flavor = [stat.name, ...lines].join('<br/>');
+      r.toMessage({ speaker: { alias: 'La Guardia' }, flavor });
     }
   }
 

--- a/src/guard/organization-stats-app.ts
+++ b/src/guard/organization-stats-app.ts
@@ -70,7 +70,15 @@ export default class OrganizationStatsApp extends Application {
     );
     const r = new Roll(`1d20 + ${stat.value + bonus}`);
     r.evaluate({ async: false });
-    r.toMessage({ speaker: { alias: "Guardia" }, flavor: stat.name });
+
+    const lines: string[] = [];
+    for (const m of this.modifiers) {
+      const v = m.mods[key];
+      if (v) lines.push(`${m.name} ${v > 0 ? '+' : ''}${v}`);
+    }
+
+    const flavor = [stat.name, ...lines].join('<br/>');
+    r.toMessage({ speaker: { alias: "La Guardia" }, flavor });
   }
 
   private async _promptForStat(


### PR DESCRIPTION
## Summary
- show contributions to a roll in Guard and Patrol views
- label rolls as coming from "La Guardia" or the specific patrol

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_687199eac1c08321a97e7183c4dd42df