### PR TITLE
Show guard base stat in roll messages

### DIFF
--- a/src/components/groups/groups.svelte
+++ b/src/components/groups/groups.svelte
@@ -180,7 +180,7 @@
     const r = new Roll(`1d20 + ${total}`);
     r.evaluate({ async: false });
 
-    const lines: string[] = [stat.name];
+    const lines: string[] = [stat.name, `Valor base de la guardia ${stat.value}`];
     const guardMod = guardBonus(stat.key);
     if (guardMod) {
       lines.push(`Modificador de la guardia ${guardMod > 0 ? '+' : ''}${guardMod}`);

--- a/src/guard/organization-stats-app.ts
+++ b/src/guard/organization-stats-app.ts
@@ -71,7 +71,7 @@ export default class OrganizationStatsApp extends Application {
     const r = new Roll(`1d20 + ${stat.value + bonus}`);
     r.evaluate({ async: false });
 
-    const lines: string[] = [];
+    const lines: string[] = [`Valor base de la guardia ${stat.value}`];
     for (const m of this.modifiers) {
       const v = m.mods[key];
       if (v) lines.push(`${m.name} ${v > 0 ? '+' : ''}${v}`);


### PR DESCRIPTION
## Summary
- display the guard's base stat in group roll messages
- show the guard's base stat when rolling from the organization stats app

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68719d97375483219bb13b04441574a0