### PR TITLE
Add FilePicker for stat image editing

### DIFF
--- a/src/components/guard/guard.svelte
+++ b/src/components/guard/guard.svelte
@@ -12,6 +12,9 @@
   } from '@/guard/stats';
   import { onMount } from 'svelte';
 
+  // FilePicker is provided by Foundry at runtime
+  declare const FilePicker: any;
+
   interface Stat extends GuardStat {}
 
   let stats: Stat[] = [];
@@ -160,8 +163,17 @@
 
   function onImageClick(stat: Stat) {
     if (editing) {
-      const input = document.getElementById(`file-${stat.key}`) as HTMLInputElement | null;
-      input?.click();
+      if (typeof FilePicker !== 'undefined') {
+        // @ts-ignore - FilePicker is provided by Foundry at runtime
+        FilePicker.create({
+          type: 'image',
+          current: stat.img,
+          callback: (path: string) => {
+            stat.img = path;
+            updateStat();
+          },
+        }).render(true);
+      }
     } else {
       const bonus = modifiers.reduce(
         (acc, m) => acc + (m.mods[stat.key] || 0),


### PR DESCRIPTION
## Summary
- allow stat images to be chosen via Foundry's FilePicker when editing

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6871a56fcff88321be5d22cc6cdc0722