### PR TITLE
Fix FilePicker usage

### DIFF
--- a/src/components/groups/groups.svelte
+++ b/src/components/groups/groups.svelte
@@ -155,7 +155,7 @@
     // Prefer Foundry's file picker when available
     if (typeof FilePicker !== 'undefined') {
       // @ts-ignore - FilePicker is provided by Foundry at runtime
-      FilePicker.create({
+      new FilePicker({
         type: 'image',
         current: skill.img,
         callback: (path: string) => {

--- a/src/components/guard/guard.svelte
+++ b/src/components/guard/guard.svelte
@@ -165,7 +165,7 @@
     if (editing) {
       if (typeof FilePicker !== 'undefined') {
         // @ts-ignore - FilePicker is provided by Foundry at runtime
-        FilePicker.create({
+        new FilePicker({
           type: 'image',
           current: stat.img,
           callback: (path: string) => {


### PR DESCRIPTION
## Summary
- use `new FilePicker` instead of the deprecated `FilePicker.create`

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6871a797ccec832196082c27fa29296b