### PR TITLE
Fix guard image refresh

### DIFF
--- a/src/components/guard/guard.svelte
+++ b/src/components/guard/guard.svelte
@@ -100,6 +100,7 @@
         action: 'edit',
       },
     ];
+    stats = [...stats];
     await persist();
   }
 
@@ -244,6 +245,7 @@
   }
 
   async function updateResource() {
+    resources = [...resources];
     await persistRes();
   }
 


### PR DESCRIPTION
## Summary
- trigger Svelte reactivity when updating guard stats or resources

## Testing
- `npm run format`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6871a91819f48321aed840b173071ff3